### PR TITLE
fix blog post page, fix broken image

### DIFF
--- a/_posts/2017-06-11-RealityWinner.md
+++ b/_posts/2017-06-11-RealityWinner.md
@@ -16,7 +16,7 @@ tags:
 #
 header: no
 image:
- thumb: "image/courage.jpeg"
+ thumb: "courage.jpeg"
 ---
 
 ![RealityWinner](/images/blogimages/reality-winner.jpg)

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,6 +3,5 @@ layout: blog
 title: "Lucy Parsons Labs Blog"
 teaser: "What We've Been Up To"
 header: no
-permalink: /blog/
 ---
 


### PR DESCRIPTION
If committed, this fix will address #160 and repair a broken url in the latest blog post (not caught because it was unable to be tested)