### PR TITLE
add direct link to our PayPal

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,7 +18,7 @@ layout: compress
           digital rights | civic transparency | data liberation
         </p>
         <p>
-        <a href="{{ site.url }}/support"><span class="donate">DONATE</span></a>
+        <a href="https://paypal.me/lucyparsonslabs"><span class="donate">DONATE</span></a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This PR links directly to our PayPal which I think will be better for click-through rates for supporters. 