### PR TITLE
Delete existing built _site directory before building

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,7 @@ def publish_to_server(site_config)
     else
       config = '_config.yml'
     end
+    sh "rm -r _site"
     sh "bundle exec jekyll build --config #{config}"
     puts 'Publishing the contents of _site'
     user = 'lpldeploy'
@@ -90,6 +91,7 @@ def publish_to_s3(site_config)
     else
       config = '_config.yml'
     end
+    sh "rm -r _site"
     sh "bundle exec jekyll build --config #{config}"
     puts "Publishing the contents of _site to s3 bucket #{s3_bucket}"
     sh "aws s3 sync _site s3://#{s3_bucket}/ --delete --cache-control max-age=#{cache_control_timeout}"


### PR DESCRIPTION
We've had a few errant doubleposts show up, and I think it's partly because people's _site directories had old content lying around.
(the other part is unclean working directories, but I've always been leery about scripts messing with folks' local git checkouts.)
This wipes out `_site` on each build so we're starting fresh. It actually doesn't add much if anything to the deploy time.

The True Fix for this is having CI, but "LPL Jenkins" is not a world I want to be in yet.