### PR TITLE
Add GitHub build actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python', 'ruby' ]
+        language: [ 'javascript', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,32 @@
+name: Deploy dev
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ develop ]
+permissions:
+  contents: read
+env:
+  AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: try to authenticate to aws
+      run: aws sts get-caller-identity
+    - name: Run build
+      run: bundle exec rake deploy

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,8 +1,8 @@
-name: Deploy dev
+name: Deploy prod
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
 permissions:
   contents: read
 env:
@@ -24,4 +24,4 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - name: Run build
-      run: bundle exec rake deploy
+      run: bundle exec rake deploy_prod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
-name: Ruby
+name: Build site
 
-on: [push, pull_request]
+on: push
 
 permissions:
   contents: read
@@ -14,7 +14,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run build
       run: bundle exec rake build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Our members have a variety of projects and collaborations in the works. Some exa
 We are a transparency non-profit that seeks to engage our community in a horizontal manner while organizing around digital rights issues, supporting free and open source projects and seeking the free flow of information globally.
 
 ## How to Develop On This Site
-It's a reasonably simply jekyll site. You'll want to get a modern version of Ruby installed, via rbenv or rvm if you prefer. You should `gem install bundler` of some variety if you haven't already, and `bundle install` will provide the versions of Rake and Jekyll that this project currently uses. From there, `rake dev` will start a local env that you can reach at http://localhost:4000/ with any changes you wish to test. To deploy to the website, you need access to our S3 bucket.
+It's a reasonably simply jekyll site. You'll want to get a modern version of Ruby installed, via rbenv or rvm if you prefer. You should `gem install bundler` of some variety if you haven't already, and `bundle install` will provide the versions of Rake and Jekyll that this project currently uses. From there, `rake dev` will start a local env that you can reach at http://localhost:4000/ with any changes you wish to test. 
+
+## Deployment
+The site is deployed through Github Actions. There are two branches that get deployed when commits are added to them:
+* `develop` gets deployed to https://staging.lucyparsonslabs.com
+* `main` gets deployed to https://lucyparsonslabs.com
 
 ## Style Guide
 Our website art was created using [pxlsrt](https://github.com/czycha/pxlsrt), a Ruby gem. For more information, see the [style guide](STYLE.md).


### PR DESCRIPTION
This changes deployments from being a thing that happens on our laptops to a thing that GitHub Actions does for us.

The following workflows are created here:
* the "build site" job, which builds the site for PRs and throws it away to make sure that jekyll doesn't choke on changes
* the "deploy dev" job, which builds the site and deploys it to staging when commits are added to `develop`
* the "deploy prod" job, which builds the site and deploys it to production when commits are added to `main`

I have also updated the repo to change the way things work in terms of git use, as we are now using `develop` as the default branch, and changes must be separately PRed into `main` to actually see production deployment.